### PR TITLE
Update Configuration class use modern TreeBuilder

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -9,8 +9,7 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('wmc_doctrine_naming_strategy');
+        $treeBuilder = new TreeBuilder('wmc_doctrine_naming_strategy');
 
         return $treeBuilder;
     }


### PR DESCRIPTION
Updates the `Configuration` class to provide the root name to the `TreeBuilder` constructor.

Constructing `TreeBuilder` without a name was raising a deprecation notice in [4.x versions of config](https://github.com/symfony/config/blob/7c97a6dc7f672fbd08133a7f601e1ac8ec9d6cb5/Definition/Builder/TreeBuilder.php#L30) and was [completely removed](https://github.com/symfony/config/blob/5.3/CHANGELOG.md#500) in 5.x, so now this bundle is not compatible with modern symfony versions.